### PR TITLE
Switched the compareAndSet in the shutdown() method

### DIFF
--- a/src/main/java/com/nukkitx/proxypass/ProxyPass.java
+++ b/src/main/java/com/nukkitx/proxypass/ProxyPass.java
@@ -138,7 +138,7 @@ public class ProxyPass {
     }
 
     public void shutdown() {
-        if (running.compareAndSet(false, true)) {
+        if (running.compareAndSet(true, false)) {
             synchronized (this) {
                 this.notify();
             }


### PR DESCRIPTION
The program wouldn't actually shut down since running would be set to true instead of false