### PR TITLE
Fix compilation under Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -93,11 +94,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.3</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>2.13.1</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -111,7 +113,7 @@
                 <configuration>
                     <transformers>
                         <transformer
-                                implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                                implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
                         </transformer>
                     </transformers>
                 </configuration>


### PR DESCRIPTION
The pom specifies no version for the Jar and the shade plugin, so I were getting these warnings:
```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for com.nukkitx:proxypass:jar:1.0.0-SNAPSHOT[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 80, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-shade-plugin is missing. @ line 93, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```

The compilation also halted right at the end during shade:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.2.3:shade (default) on project proxypass: Execution default of goal org.apache.maven.plugins:maven-shade-plugin:3.2.3:shade failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-shade-plugin:3.2.3:shade: java.lang.AbstractMethodError: com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer.processResource(Ljava/lang/String;Ljava/io/InputStream;Ljava/util/List;J)V
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.apache.maven.plugins:maven-shade-plugin:3.2.3
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/home/marcos/.m2/repository/org/apache/maven/plugins/maven-shade-plugin/3.2.3/maven-shade-plugin-3.2.3.jar
[ERROR] urls[1] = file:/home/marcos/.m2/repository/com/github/edwgiz/maven-shade-plugin.log4j2-cachefile-transformer/2.8.1/maven-shade-plugin.log4j2-cachefile-transformer-2.8.1.jar
[ERROR] urls[2] = file:/home/marcos/.m2/repository/org/apache/logging/log4j/log4j-api/2.8.1/log4j-api-2.8.1.jar
[ERROR] urls[3] = file:/home/marcos/.m2/repository/org/apache/logging/log4j/log4j-core/2.8.1/log4j-core-2.8.1.jar
[ERROR] urls[4] = file:/home/marcos/.m2/repository/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar
[ERROR] urls[5] = file:/home/marcos/.m2/repository/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-noaop.jar
[ERROR] urls[6] = file:/home/marcos/.m2/repository/org/sonatype/aether/aether-util/1.7/aether-util-1.7.jar
[ERROR] urls[7] = file:/home/marcos/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar
[ERROR] urls[8] = file:/home/marcos/.m2/repository/org/codehaus/plexus/plexus-component-annotations/2.0.0/plexus-component-annotations-2.0.0.jar
[ERROR] urls[9] = file:/home/marcos/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
[ERROR] urls[10] = file:/home/marcos/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
[ERROR] urls[11] = file:/home/marcos/.m2/repository/org/codehaus/plexus/plexus-utils/3.3.0/plexus-utils-3.3.0.jar
[ERROR] urls[12] = file:/home/marcos/.m2/repository/org/apache/maven/shared/maven-artifact-transfer/0.12.0/maven-artifact-transfer-0.12.0.jar
[ERROR] urls[13] = file:/home/marcos/.m2/repository/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar
[ERROR] urls[14] = file:/home/marcos/.m2/repository/org/apache/maven/shared/maven-shared-utils/3.1.0/maven-shared-utils-3.1.0.jar
[ERROR] urls[15] = file:/home/marcos/.m2/repository/commons-codec/commons-codec/1.11/commons-codec-1.11.jar
[ERROR] urls[16] = file:/home/marcos/.m2/repository/org/ow2/asm/asm/8.0/asm-8.0.jar
[ERROR] urls[17] = file:/home/marcos/.m2/repository/org/ow2/asm/asm-commons/8.0/asm-commons-8.0.jar
[ERROR] urls[18] = file:/home/marcos/.m2/repository/org/ow2/asm/asm-tree/8.0/asm-tree-8.0.jar
[ERROR] urls[19] = file:/home/marcos/.m2/repository/org/ow2/asm/asm-analysis/8.0/asm-analysis-8.0.jar
[ERROR] urls[20] = file:/home/marcos/.m2/repository/org/jdom/jdom2/2.0.6/jdom2-2.0.6.jar
[ERROR] urls[21] = file:/home/marcos/.m2/repository/org/apache/maven/shared/maven-dependency-tree/3.0.1/maven-dependency-tree-3.0.1.jar
[ERROR] urls[22] = file:/home/marcos/.m2/repository/org/eclipse/aether/aether-util/0.9.0.M2/aether-util-0.9.0.M2.jar
[ERROR] urls[23] = file:/home/marcos/.m2/repository/commons-io/commons-io/2.5/commons-io-2.5.jar
[ERROR] urls[24] = file:/home/marcos/.m2/repository/org/vafer/jdependency/2.4.0/jdependency-2.4.0.jar
[ERROR] urls[25] = file:/home/marcos/.m2/repository/org/ow2/asm/asm-util/8.0/asm-util-8.0.jar
[ERROR] urls[26] = file:/home/marcos/.m2/repository/com/google/guava/guava/19.0/guava-19.0.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
[ERROR]
```

[According to StackOverflow](https://stackoverflow.com/questions/32382445/an-api-incompatibility-was-encountered-while-executing-org-apache-maven-plugins) this is an issue with a breaking change in transform plugins which I've solved by updating the `maven-shade-plugin.log4j2-cachefile-transformer` plugin to the latest.