### PR TITLE
Add option to log packets to console and don't create folder with packet logging off

### DIFF
--- a/src/main/java/com/nukkitx/proxypass/Configuration.java
+++ b/src/main/java/com/nukkitx/proxypass/Configuration.java
@@ -26,6 +26,8 @@ public class Configuration {
     private boolean packetTesting = false;
     @JsonProperty("log-packets")
     private boolean loggingPackets = false;
+    @JsonProperty("log-to")
+    private String logTo = "file";
 
     @JsonProperty("ignored-packets")
     private Set<String> ignoredPackets = Collections.emptySet();

--- a/src/main/java/com/nukkitx/proxypass/Configuration.java
+++ b/src/main/java/com/nukkitx/proxypass/Configuration.java
@@ -1,6 +1,7 @@
 package com.nukkitx.proxypass;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.nukkitx.proxypass.network.bedrock.util.LogTo;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -27,7 +28,7 @@ public class Configuration {
     @JsonProperty("log-packets")
     private boolean loggingPackets = false;
     @JsonProperty("log-to")
-    private String logTo = "file";
+    private LogTo logTo = LogTo.FILE;
 
     @JsonProperty("ignored-packets")
     private Set<String> ignoredPackets = Collections.emptySet();

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/session/ProxyPlayerSession.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/session/ProxyPlayerSession.java
@@ -8,6 +8,7 @@ import com.nukkitx.protocol.bedrock.BedrockSession;
 import com.nukkitx.protocol.bedrock.handler.BatchHandler;
 import com.nukkitx.protocol.bedrock.handler.BedrockPacketHandler;
 import com.nukkitx.protocol.bedrock.util.EncryptionUtils;
+import com.nukkitx.proxypass.Configuration;
 import com.nukkitx.proxypass.ProxyPass;
 import io.netty.buffer.ByteBuf;
 import lombok.AccessLevel;
@@ -49,7 +50,7 @@ public class ProxyPlayerSession {
         this.dataPath = proxy.getSessionsDir().resolve(this.authData.getDisplayName() + '-' + timestamp);
         this.logPath = dataPath.resolve("packets.log");
         if (proxy.getConfiguration().isLoggingPackets() &&
-                (proxy.getConfiguration().getLogTo().equals("file") || proxy.getConfiguration().getLogTo().equals("both"))) {
+                proxy.getConfiguration().getLogTo().logToFile) {
             log.debug("Packets will be logged under " + logPath.toString());
             try {
                 Files.createDirectories(dataPath);
@@ -86,7 +87,7 @@ public class ProxyPlayerSession {
     private void flushLogBuffer() {
         synchronized (logBuffer) {
             try {
-                if (proxy.getConfiguration().getLogTo().equals("file") || proxy.getConfiguration().getLogTo().equals("both")) {
+                if (proxy.getConfiguration().getLogTo().logToFile) {
                     Files.write(logPath, logBuffer, StandardOpenOption.APPEND, StandardOpenOption.CREATE);
                 }
                 logBuffer.clear();
@@ -117,7 +118,7 @@ public class ProxyPlayerSession {
                     }
                     ProxyPlayerSession.this.log(() -> logPrefix + packet.toString());
                     if (proxy.getConfiguration().isLoggingPackets() &&
-                            proxy.getConfiguration().getLogTo().equals("console") || proxy.getConfiguration().getLogTo().equals("both")) {
+                            proxy.getConfiguration().getLogTo().logToConsole) {
                         System.out.println(logPrefix + packet.toString());
                     }
                 }

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/session/ProxyPlayerSession.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/session/ProxyPlayerSession.java
@@ -8,7 +8,6 @@ import com.nukkitx.protocol.bedrock.BedrockSession;
 import com.nukkitx.protocol.bedrock.handler.BatchHandler;
 import com.nukkitx.protocol.bedrock.handler.BedrockPacketHandler;
 import com.nukkitx.protocol.bedrock.util.EncryptionUtils;
-import com.nukkitx.proxypass.Configuration;
 import com.nukkitx.proxypass.ProxyPass;
 import io.netty.buffer.ByteBuf;
 import lombok.AccessLevel;

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/util/ForgeryUtils.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/util/ForgeryUtils.java
@@ -1,23 +1,15 @@
 package com.nukkitx.proxypass.network.bedrock.util;
 
 import com.nimbusds.jose.*;
-import com.nimbusds.jose.crypto.ECDSASigner;
-import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nukkitx.protocol.bedrock.util.EncryptionUtils;
 import lombok.experimental.UtilityClass;
 import net.minidev.json.JSONObject;
 
-import javax.crypto.KeyAgreement;
-import javax.crypto.SecretKey;
 import java.net.URI;
-import java.security.*;
+import java.security.KeyPair;
 import java.security.interfaces.ECPrivateKey;
-import java.security.interfaces.ECPublicKey;
-import java.security.spec.ECGenParameterSpec;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/util/LogTo.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/util/LogTo.java
@@ -1,0 +1,25 @@
+package com.nukkitx.proxypass.network.bedrock.util;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum LogTo {
+    @JsonProperty("file")
+    FILE,
+    @JsonProperty("console")
+    CONSOLE,
+    @JsonProperty("both")
+    BOTH;
+
+    public boolean logToFile;
+    public boolean logToConsole;
+
+    static {
+        FILE.logToFile = true;
+        CONSOLE.logToFile = false;
+        BOTH.logToFile = true;
+
+        FILE.logToConsole = false;
+        CONSOLE.logToConsole = true;
+        BOTH.logToConsole = true;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,6 +11,9 @@ destination:
 packet-testing: false
 ## Log packets for each session
 log-packets: true
+## Where to log packet data
+## Valid options: console, file or both
+log-to: file
 
 ## Packets to ignore to make your log more refined. These default packet are generally spammed
 ignored-packets:


### PR DESCRIPTION
This PR allows you to select the logging destination, and doesn't create the session folder when nothing is going to be written to it.