### PR TITLE
Improve pong

### DIFF
--- a/src/main/java/com/nukkitx/proxypass/ProxyPass.java
+++ b/src/main/java/com/nukkitx/proxypass/ProxyPass.java
@@ -47,9 +47,8 @@ public class ProxyPass {
         PRETTY_PRINTER.indentObjectsWith(indenter);
         String minecraftVersion;
 
-        Package mainPackage = ProxyPass.class.getPackage();
         try {
-            minecraftVersion = mainPackage.getImplementationVersion().split("-")[0];
+            minecraftVersion = CODEC.getMinecraftVersion();
         } catch (NullPointerException e) {
             minecraftVersion = "0.0.0";
         }

--- a/src/main/java/com/nukkitx/proxypass/network/ProxyBedrockEventHandler.java
+++ b/src/main/java/com/nukkitx/proxypass/network/ProxyBedrockEventHandler.java
@@ -32,7 +32,9 @@ public class ProxyBedrockEventHandler implements BedrockServerEventHandler {
 
     public ProxyBedrockEventHandler(ProxyPass proxy) {
         this.proxy = proxy;
-        ADVERTISEMENT.setIpv4Port(this.proxy.getProxyAddress().getPort());
+        int port = this.proxy.getProxyAddress().getPort();
+        ADVERTISEMENT.setIpv4Port(port);
+        ADVERTISEMENT.setIpv6Port(port);
     }
 
     @Override

--- a/src/main/java/com/nukkitx/proxypass/network/ProxyBedrockEventHandler.java
+++ b/src/main/java/com/nukkitx/proxypass/network/ProxyBedrockEventHandler.java
@@ -13,7 +13,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.net.InetSocketAddress;
 
 @Log4j2
-@RequiredArgsConstructor
 @ParametersAreNonnullByDefault
 public class ProxyBedrockEventHandler implements BedrockServerEventHandler {
     private static final BedrockPong ADVERTISEMENT = new BedrockPong();
@@ -29,6 +28,11 @@ public class ProxyBedrockEventHandler implements BedrockServerEventHandler {
         ADVERTISEMENT.setPlayerCount(0);
         ADVERTISEMENT.setMaximumPlayerCount(20);
         ADVERTISEMENT.setSubMotd("https://github.com/NukkitX/ProxyPass");
+    }
+
+    public ProxyBedrockEventHandler(ProxyPass proxy) {
+        this.proxy = proxy;
+        ADVERTISEMENT.setIpv4Port(this.proxy.getProxyAddress().getPort());
     }
 
     @Override


### PR DESCRIPTION
Pong is missing some data:
* Minecraft version. Fixed;
* Ipv4 port. Fixed;
* Ipv6 port. But this can't really be fixed right now, since ProxyPass doesn't actually config or bind a second port.

Compare these:

BDS Pong:
`MCPE;Dedicated Server;407;1.16.1;0;10;9320212127489529623;Bedrock level;Survival;1;19130;19131;`

ProxyPass Pong before fixes:
`MCPE;ProxyPass;407;0.0.0;0;20;-2326465236099870380;https://github.com/NukkitX/ProxyPass;Survival;1;-1;-1`

ProxyPass after fixes:
`MCPE;ProxyPass;407;1.16.0;0;20;-2326465236099870380;https://github.com/NukkitX/ProxyPass;Survival;1;19132;-1`

Also note the missing semicolon, for which I've openend CloudburstMC/Protocol#61.