### PR TITLE
Don't use PONG ports

### DIFF
--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/session/UpstreamPacketHandler.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/session/UpstreamPacketHandler.java
@@ -129,7 +129,7 @@ public class UpstreamPacketHandler implements BedrockPacketHandler {
         log.debug("Initializing proxy session");
         BedrockClient client = proxy.newClient();
         client.setRakNetVersion(10);
-        client.connect(proxy.getTargetAddress()).whenComplete((downstream, throwable) -> {
+        client.directConnect(proxy.getTargetAddress()).whenComplete((downstream, throwable) -> {
             if (throwable != null) {
                 log.error("Unable to connect to downstream server " + proxy.getTargetAddress(), throwable);
                 return;


### PR DESCRIPTION
This fixes a bedrock server being port forwarded with a different port than configured. For example BDS:19130 and a router with port 19133 forwarding.

If trying to connect using a bedrock client in this config, proxypass will make a single ping to the downstream server, then update its port to that returned in the pong packet (if not -1) and then continue trying to connect.

We simply skip this step and honour the port specified in the config file.
