### PR TITLE
Refactor: pull log file writing logic into an separate object

### DIFF
--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/logging/PacketLogger.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/logging/PacketLogger.java
@@ -1,25 +1,49 @@
 package com.nukkitx.proxypass.network.bedrock.logging;
 
+import com.nukkitx.protocol.bedrock.BedrockPacket;
+import com.nukkitx.protocol.bedrock.BedrockSession;
+import com.nukkitx.proxypass.Configuration;
+import com.nukkitx.proxypass.ProxyPass;
+import lombok.extern.log4j.Log4j2;
+
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
+
+@Log4j2
 public class PacketLogger {
 
     public static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+    private final ProxyPass proxy;
 
     private final Path dataPath;
 
     private final Path logPath;
 
-    public PacketLogger(Path dataPath, Path logPath) {
-        this.dataPath = dataPath;
-        this.logPath = logPath;
-    }
+    private final Deque<String> logBuffer = new ArrayDeque<>();
 
-    public PacketLogger(Path sessionsDir, String displayName, long timestamp) {
+    public PacketLogger(ProxyPass proxy, Path sessionsDir, String displayName, long timestamp) {
+        this.proxy = proxy;
         this.dataPath = sessionsDir.resolve(displayName + '-' + timestamp);
         this.logPath = dataPath.resolve("packets.log");
+
+        if (proxy.getConfiguration().isLoggingPackets() && proxy.getConfiguration().getLogTo().logToFile) {
+            log.debug("Packets will be logged under " + getLogPath().toString());
+            try {
+                Files.createDirectories(getDataPath());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     public Path getDataPath() {
@@ -28,6 +52,54 @@ public class PacketLogger {
 
     public Path getLogPath() {
         return logPath;
+    }
+
+    public Deque<String> getLogBuffer() {
+        return logBuffer;
+    }
+
+    public void log(Supplier<String> supplier) {
+        if (proxy.getConfiguration().isLoggingPackets()) {
+            synchronized (getLogBuffer()) {
+                getLogBuffer().addLast(supplier.get());
+            }
+        }
+    }
+
+    private void flushLogBuffer() {
+        synchronized (getLogBuffer()) {
+            try {
+                if (proxy.getConfiguration().getLogTo().logToFile) {
+                    Files.write(getLogPath(), getLogBuffer(), StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+                }
+                getLogBuffer().clear();
+            } catch (IOException e) {
+                log.error("Unable to flush packet log", e);
+            }
+        }
+    }
+
+    public void start(ProxyPass proxy) {
+        if (proxy.getConfiguration().isLoggingPackets()) {
+            executor.scheduleAtFixedRate(this::flushLogBuffer, 5, 5, TimeUnit.SECONDS);
+        }
+    }
+
+    public void logPacket(BedrockSession session, BedrockPacket packet, boolean upstream) {
+        String logPrefix = getLogPrefix(upstream);
+        if (!proxy.isIgnoredPacket(packet.getClass())) {
+            if (session.isLogging() && log.isTraceEnabled()) {
+                log.trace(logPrefix + " {}: {}", session.getAddress(), packet);
+            }
+            log(() -> logPrefix + packet.toString());
+            if (proxy.getConfiguration().isLoggingPackets() && proxy.getConfiguration().getLogTo().logToConsole) {
+                System.out.println(logPrefix + packet.toString());
+            }
+        }
+    }
+
+    private String getLogPrefix(boolean upstream) {
+        return upstream ? "[SERVER BOUND]  -  " : "[CLIENT BOUND]  -  ";
     }
 
 }

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/logging/PacketLogger.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/logging/PacketLogger.java
@@ -2,11 +2,14 @@ package com.nukkitx.proxypass.network.bedrock.logging;
 
 import com.nukkitx.protocol.bedrock.BedrockPacket;
 import com.nukkitx.protocol.bedrock.BedrockSession;
-import com.nukkitx.proxypass.Configuration;
 import com.nukkitx.proxypass.ProxyPass;
+import com.nukkitx.proxypass.network.bedrock.session.ProxyPlayerSession;
 import lombok.extern.log4j.Log4j2;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/logging/PacketLogger.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/logging/PacketLogger.java
@@ -1,0 +1,33 @@
+package com.nukkitx.proxypass.network.bedrock.logging;
+
+import java.nio.file.Path;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class PacketLogger {
+
+    public static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+    private final Path dataPath;
+
+    private final Path logPath;
+
+    public PacketLogger(Path dataPath, Path logPath) {
+        this.dataPath = dataPath;
+        this.logPath = logPath;
+    }
+
+    public PacketLogger(Path sessionsDir, String displayName, long timestamp) {
+        this.dataPath = sessionsDir.resolve(displayName + '-' + timestamp);
+        this.logPath = dataPath.resolve("packets.log");
+    }
+
+    public Path getDataPath() {
+        return dataPath;
+    }
+
+    public Path getLogPath() {
+        return logPath;
+    }
+
+}

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/logging/SessionLogger.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/logging/SessionLogger.java
@@ -44,7 +44,7 @@ public class SessionLogger {
         this.logPath = dataPath.resolve("packets.log");
     }
 
-    public void start(ProxyPass proxy) {
+    public void start() {
         if (proxy.getConfiguration().isLoggingPackets()){
             if (proxy.getConfiguration().getLogTo().logToFile) {
                 log.debug("Packets will be logged under " + logPath.toString());

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/logging/SessionLogger.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/logging/SessionLogger.java
@@ -42,14 +42,19 @@ public class SessionLogger {
         this.proxy = proxy;
         this.dataPath = sessionsDir.resolve(displayName + '-' + timestamp);
         this.logPath = dataPath.resolve("packets.log");
+    }
 
-        if (proxy.getConfiguration().isLoggingPackets() && proxy.getConfiguration().getLogTo().logToFile) {
-            log.debug("Packets will be logged under " + logPath.toString());
-            try {
-                Files.createDirectories(dataPath);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+    public void start(ProxyPass proxy) {
+        if (proxy.getConfiguration().isLoggingPackets()){
+            if (proxy.getConfiguration().getLogTo().logToFile) {
+                log.debug("Packets will be logged under " + logPath.toString());
+                try {
+                    Files.createDirectories(dataPath);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
+            executor.scheduleAtFixedRate(this::flushLogBuffer, 5, 5, TimeUnit.SECONDS);
         }
     }
 
@@ -99,12 +104,6 @@ public class SessionLogger {
             } catch (IOException e) {
                 log.error("Unable to flush packet log", e);
             }
-        }
-    }
-
-    public void start(ProxyPass proxy) {
-        if (proxy.getConfiguration().isLoggingPackets()) {
-            executor.scheduleAtFixedRate(this::flushLogBuffer, 5, 5, TimeUnit.SECONDS);
         }
     }
 

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/logging/SessionLogger.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/logging/SessionLogger.java
@@ -26,7 +26,7 @@ import java.util.function.Supplier;
 
 
 @Log4j2
-public class PacketLogger {
+public class SessionLogger {
 
     private static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
@@ -38,7 +38,7 @@ public class PacketLogger {
 
     private final Deque<String> logBuffer = new ArrayDeque<>();
 
-    public PacketLogger(ProxyPass proxy, Path sessionsDir, String displayName, long timestamp) {
+    public SessionLogger(ProxyPass proxy, Path sessionsDir, String displayName, long timestamp) {
         this.proxy = proxy;
         this.dataPath = sessionsDir.resolve(displayName + '-' + timestamp);
         this.logPath = dataPath.resolve("packets.log");

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/logging/SessionLogger.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/logging/SessionLogger.java
@@ -94,11 +94,11 @@ public class SessionLogger {
             }
 
             if (proxy.getConfiguration().isLoggingPackets()) {
-                logToBuffer(() -> logPrefix + packet.toString());
+                logToBuffer(() -> logPrefix + packet);
             }
 
             if (proxy.getConfiguration().isLoggingPackets() && proxy.getConfiguration().getLogTo().logToConsole) {
-                System.out.println(logPrefix + packet.toString());
+                System.out.println(logPrefix + packet);
             }
         }
     }

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/session/ProxyPlayerSession.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/session/ProxyPlayerSession.java
@@ -40,17 +40,17 @@ public class ProxyPlayerSession {
         this.downstream = downstream;
         this.proxy = proxy;
         this.authData = authData;
+        this.upstream.addDisconnectHandler(reason -> {
+            if (reason != DisconnectReason.DISCONNECTED) {
+                this.downstream.disconnect();
+            }
+        });
         this.logger = new SessionLogger(
                 proxy,
                 proxy.getSessionsDir(),
                 this.authData.getDisplayName(),
                 timestamp
         );
-        this.upstream.addDisconnectHandler(reason -> {
-            if (reason != DisconnectReason.DISCONNECTED) {
-                this.downstream.disconnect();
-            }
-        });
         logger.start(proxy);
     }
 

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/session/ProxyPlayerSession.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/session/ProxyPlayerSession.java
@@ -51,7 +51,7 @@ public class ProxyPlayerSession {
                 this.authData.getDisplayName(),
                 timestamp
         );
-        logger.start(proxy);
+        logger.start();
     }
 
     public BatchHandler getUpstreamBatchHandler() {

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/session/ProxyPlayerSession.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/session/ProxyPlayerSession.java
@@ -11,7 +11,7 @@ import com.nukkitx.protocol.bedrock.handler.BedrockPacketHandler;
 import com.nukkitx.protocol.bedrock.packet.UnknownPacket;
 import com.nukkitx.protocol.bedrock.util.EncryptionUtils;
 import com.nukkitx.proxypass.ProxyPass;
-import com.nukkitx.proxypass.network.bedrock.logging.PacketLogger;
+import com.nukkitx.proxypass.network.bedrock.logging.SessionLogger;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import lombok.AccessLevel;
@@ -33,14 +33,14 @@ public class ProxyPlayerSession {
     private final KeyPair proxyKeyPair = EncryptionUtils.createKeyPair();
     private volatile boolean closed = false;
 
-    public final PacketLogger logger;
+    public final SessionLogger logger;
 
     public ProxyPlayerSession(BedrockServerSession upstream, BedrockClientSession downstream, ProxyPass proxy, AuthData authData) {
         this.upstream = upstream;
         this.downstream = downstream;
         this.proxy = proxy;
         this.authData = authData;
-        this.logger = new PacketLogger(
+        this.logger = new SessionLogger(
                 proxy,
                 proxy.getSessionsDir(),
                 this.authData.getDisplayName(),
@@ -63,11 +63,11 @@ public class ProxyPlayerSession {
     }
 
     private class ProxyBatchHandler implements BatchHandler {
-        private final PacketLogger logger;
+        private final SessionLogger logger;
         private final BedrockSession session;
         private final boolean upstream;
 
-        private ProxyBatchHandler(BedrockSession session, PacketLogger logger, boolean upstream) {
+        private ProxyBatchHandler(BedrockSession session, SessionLogger logger, boolean upstream) {
             this.session = session;
             this.logger = logger;
             this.upstream = upstream;

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/session/UpstreamPacketHandler.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/session/UpstreamPacketHandler.java
@@ -146,7 +146,7 @@ public class UpstreamPacketHandler implements BedrockPacketHandler {
                 JsonNode payload = ProxyPass.JSON_MAPPER.readTree(jwt.getPayload().toBytes());
                 ObjectWriter jsonout = ProxyPass.JSON_MAPPER.writer(new DefaultPrettyPrinter());
                 jsonout.writeValue(new FileOutputStream(player.logger.getLogPath().getParent().resolve("chainData.json").toFile()), payload);
-                jsonout.writeValue(new FileOutputStream(player.logger.getLogPath().getParent().resolve("skinData.json").toFile()), skinData);
+                jsonout.writeValue(new FileOutputStream(player.getLogger().getLogPath().getParent().resolve("skinData.json").toFile()), skinData);
             } catch (Exception e) {
                 log.error("JSON output error: " + e.getMessage(), e);
             }

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/session/UpstreamPacketHandler.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/session/UpstreamPacketHandler.java
@@ -145,8 +145,8 @@ public class UpstreamPacketHandler implements BedrockPacketHandler {
                 JWSObject jwt = JWSObject.parse(chainData.get(chainData.size() - 1).asText());
                 JsonNode payload = ProxyPass.JSON_MAPPER.readTree(jwt.getPayload().toBytes());
                 ObjectWriter jsonout = ProxyPass.JSON_MAPPER.writer(new DefaultPrettyPrinter());
-                jsonout.writeValue(new FileOutputStream(player.getLogPath().getParent().resolve("chainData.json").toFile()), payload);
-                jsonout.writeValue(new FileOutputStream(player.getLogPath().getParent().resolve("skinData.json").toFile()), skinData);
+                jsonout.writeValue(new FileOutputStream(player.logger.getLogPath().getParent().resolve("chainData.json").toFile()), payload);
+                jsonout.writeValue(new FileOutputStream(player.logger.getLogPath().getParent().resolve("skinData.json").toFile()), skinData);
             } catch (Exception e) {
                 log.error("JSON output error: " + e.getMessage(), e);
             }

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/session/UpstreamPacketHandler.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/session/UpstreamPacketHandler.java
@@ -1,9 +1,7 @@
 package com.nukkitx.proxypass.network.bedrock.session;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.google.common.base.Preconditions;
@@ -24,7 +22,6 @@ import io.netty.util.AsciiString;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.security.interfaces.ECPublicKey;
 import java.util.UUID;
@@ -144,9 +141,8 @@ public class UpstreamPacketHandler implements BedrockPacketHandler {
             try {
                 JWSObject jwt = JWSObject.parse(chainData.get(chainData.size() - 1).asText());
                 JsonNode payload = ProxyPass.JSON_MAPPER.readTree(jwt.getPayload().toBytes());
-                ObjectWriter jsonout = ProxyPass.JSON_MAPPER.writer(new DefaultPrettyPrinter());
-                jsonout.writeValue(new FileOutputStream(player.logger.getLogPath().getParent().resolve("chainData.json").toFile()), payload);
-                jsonout.writeValue(new FileOutputStream(player.getLogger().getLogPath().getParent().resolve("skinData.json").toFile()), skinData);
+                player.getLogger().saveJson("chainData", payload);
+                player.getLogger().saveJson("skinData", this.skinData);
             } catch (Exception e) {
                 log.error("JSON output error: " + e.getMessage(), e);
             }
@@ -181,4 +177,5 @@ public class UpstreamPacketHandler implements BedrockPacketHandler {
             //SkinUtils.saveSkin(proxySession, this.skinData);
         });
     }
+
 }

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/util/SkinUtils.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/util/SkinUtils.java
@@ -3,15 +3,9 @@ package com.nukkitx.proxypass.network.bedrock.util;
 import com.nimbusds.jose.shaded.json.JSONObject;
 import com.nukkitx.proxypass.network.bedrock.session.ProxyPlayerSession;
 
-import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.Base64;
 
 public class SkinUtils {
@@ -44,16 +38,10 @@ public class SkinUtils {
         saveImage(session, width, height, skin, "skin");
 
         byte[] cape = Base64.getDecoder().decode(skinData.getAsString("CapeData"));
-
         saveImage(session, 64, 32, cape, "cape");
 
-        Path geometryPath = session.logger.getDataPath().resolve("geometry.json");
         byte[] geometry = Base64.getDecoder().decode(skinData.getAsString("SkinGeometry"));
-        try {
-            Files.write(geometryPath, geometry, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        session.getLogger().saveJson("geometry", geometry);
     }
 
     private static void saveImage(ProxyPlayerSession session, int width, int height, byte[] bytes, String name) {
@@ -68,11 +56,7 @@ public class SkinUtils {
             }
         }
 
-        Path path = session.logger.getDataPath().resolve(name + ".png");
-        try (OutputStream stream = Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
-            ImageIO.write(image, "png", stream);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        session.getLogger().saveImage(name, image);
     }
+
 }

--- a/src/main/java/com/nukkitx/proxypass/network/bedrock/util/SkinUtils.java
+++ b/src/main/java/com/nukkitx/proxypass/network/bedrock/util/SkinUtils.java
@@ -47,7 +47,7 @@ public class SkinUtils {
 
         saveImage(session, 64, 32, cape, "cape");
 
-        Path geometryPath = session.getDataPath().resolve("geometry.json");
+        Path geometryPath = session.logger.getDataPath().resolve("geometry.json");
         byte[] geometry = Base64.getDecoder().decode(skinData.getAsString("SkinGeometry"));
         try {
             Files.write(geometryPath, geometry, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
@@ -68,7 +68,7 @@ public class SkinUtils {
             }
         }
 
-        Path path = session.getDataPath().resolve(name + ".png");
+        Path path = session.logger.getDataPath().resolve(name + ".png");
         try (OutputStream stream = Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
             ImageIO.write(image, "png", stream);
         } catch (IOException e) {


### PR DESCRIPTION
Summary of modifications:
* introduced a new class SessionLogger to deal with all the file writing details of logging
* extracted packet logging logic from ProxyPlayerSession to SessionLogger
* extracted JSON & image writing logic in UpstreamPacketHandler & SkinUtils to SessionLogger

I am currently doing some refactoring with the code to make way for my own project.
I think this might be nice to have for the original project as well so I am upstreaming it.
