### PR TITLE
add missing repo to gradle build file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven("https://repo.opencollab.dev/maven-snapshots")
+    maven("https://repo.opencollab.dev/maven-releases")
 }
 
 dependencies {


### PR DESCRIPTION
Hey there! When trying to build this project i got an error about missing dependencies - seems like https://repo.opencollab.dev/#/maven-releases/com/nukkitx/fastutil was moved from maven-snapshots. To fix this, i've added the other repository to the build file.
https://paste.gg/p/anonymous/803195820f1547739ead52fa41ab17c4 build log with errors for reference