### PR TITLE
Update to support recent jose4j refactor in Protocol.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [libraries]
 lombok = { group = "org.projectlombok", name = "lombok", version = "1.18.26" }
 jsr305 = { group = "com.google.code.findbugs", name = "jsr305", version = "3.0.2" }
-bedrock-codec = { group = "org.cloudburstmc.protocol", name = "bedrock-codec", version = "3.0.0.Beta1-20230612.152454-91" }
-bedrock-connection = { group = "org.cloudburstmc.protocol", name = "bedrock-connection", version = "3.0.0.Beta1-20230612.152454-90" }
+bedrock-codec = { group = "org.cloudburstmc.protocol", name = "bedrock-codec", version = "3.0.0.Beta1-20230629.114412-99" }
+bedrock-connection = { group = "org.cloudburstmc.protocol", name = "bedrock-connection", version = "3.0.0.Beta1-20230629.114412-98" }
 jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version = "2.14.2" }
 jackson-dataformat-yaml = { group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-yaml", version = "2.14.2" }
 common = { group = "com.nukkitx", name = "common", version = "1.0.1-SNAPSHOT" }

--- a/src/main/java/org/cloudburstmc/proxypass/network/bedrock/logging/SessionLogger.java
+++ b/src/main/java/org/cloudburstmc/proxypass/network/bedrock/logging/SessionLogger.java
@@ -3,11 +3,11 @@ package org.cloudburstmc.proxypass.network.bedrock.logging;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.nimbusds.jose.shaded.json.JSONObject;
 import lombok.extern.log4j.Log4j2;
 import org.cloudburstmc.protocol.bedrock.BedrockSession;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
 import org.cloudburstmc.proxypass.ProxyPass;
+import org.jose4j.json.internal.json_simple.JSONObject;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;

--- a/src/main/java/org/cloudburstmc/proxypass/network/bedrock/util/ForgeryUtils.java
+++ b/src/main/java/org/cloudburstmc/proxypass/network/bedrock/util/ForgeryUtils.java
@@ -1,18 +1,15 @@
 package org.cloudburstmc.proxypass.network.bedrock.util;
 
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.shaded.json.JSONObject;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 import lombok.experimental.UtilityClass;
-import org.cloudburstmc.protocol.bedrock.util.EncryptionUtils;
+import org.jose4j.json.internal.json_simple.JSONObject;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.NumericDate;
+import org.jose4j.jwx.HeaderParameterNames;
+import org.jose4j.lang.JoseException;
 
 import java.net.URI;
 import java.security.KeyPair;
-import java.security.interfaces.ECPrivateKey;
-import java.text.ParseException;
 import java.util.Base64;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
@@ -20,51 +17,48 @@ import java.util.concurrent.TimeUnit;
 @UtilityClass
 public class ForgeryUtils {
 
-    public static SignedJWT forgeAuthData(KeyPair pair, JSONObject extraData) {
+    public static String forgeAuthData(KeyPair pair, JSONObject extraData) {
         String publicKeyBase64 = Base64.getEncoder().encodeToString(pair.getPublic().getEncoded());
-        URI x5u = URI.create(publicKeyBase64);
-
-        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES384).x509CertURL(x5u).build();
 
         long timestamp = System.currentTimeMillis();
         Date nbf = new Date(timestamp - TimeUnit.SECONDS.toMillis(1));
         Date exp = new Date(timestamp + TimeUnit.DAYS.toMillis(1));
 
-        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
-                .notBeforeTime(nbf)
-                .expirationTime(exp)
-                .issueTime(exp)
-                .issuer("self")
-                .claim("certificateAuthority", true)
-                .claim("extraData", extraData)
-                .claim("identityPublicKey", publicKeyBase64)
-                .build();
+        JwtClaims claimsSet = new JwtClaims();
+        claimsSet.setNotBefore(NumericDate.fromMilliseconds(nbf.getTime()));
+        claimsSet.setExpirationTime(NumericDate.fromMilliseconds(exp.getTime()));
+        claimsSet.setIssuedAt(NumericDate.fromMilliseconds(exp.getTime()));
+        claimsSet.setIssuer("self");
+        claimsSet.setClaim("certificateAuthority", true);
+        claimsSet.setClaim("extraData", extraData);
+        claimsSet.setClaim("identityPublicKey", publicKeyBase64);
 
-        SignedJWT jwt = new SignedJWT(header, claimsSet);
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setPayload(claimsSet.toJson());
+        jws.setKey(pair.getPrivate());
+        jws.setAlgorithmHeaderValue("ES384");
+        jws.setHeader(HeaderParameterNames.X509_URL, publicKeyBase64);
 
         try {
-            EncryptionUtils.signJwt(jwt, (ECPrivateKey) pair.getPrivate());
-        } catch (JOSEException e) {
+            return jws.getCompactSerialization();
+        } catch (JoseException e) {
             throw new RuntimeException(e);
         }
-
-        return jwt;
     }
 
-    public static SignedJWT forgeSkinData(KeyPair pair, JSONObject skinData) {
-        URI x5u = URI.create(Base64.getEncoder().encodeToString(pair.getPublic().getEncoded()));
+    public static String forgeSkinData(KeyPair pair, JSONObject skinData) {
+        String publicKeyBase64 = Base64.getEncoder().encodeToString(pair.getPublic().getEncoded());
 
-        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES384).x509CertURL(x5u).build();
-
-        SignedJWT jws;
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setAlgorithmHeaderValue("ES384");
+        jws.setHeader(HeaderParameterNames.X509_URL, publicKeyBase64);
+        jws.setPayload(skinData.toJSONString());
+        jws.setKey(pair.getPrivate());
 
         try {
-            jws = new SignedJWT(header, JWTClaimsSet.parse(skinData));
-            EncryptionUtils.signJwt(jws, (ECPrivateKey) pair.getPrivate());
-        } catch (JOSEException | ParseException e) {
+            return jws.getCompactSerialization();
+        } catch (JoseException e) {
             throw new RuntimeException(e);
         }
-
-        return jws;
     }
 }

--- a/src/main/java/org/cloudburstmc/proxypass/network/bedrock/util/SkinUtils.java
+++ b/src/main/java/org/cloudburstmc/proxypass/network/bedrock/util/SkinUtils.java
@@ -1,7 +1,8 @@
 package org.cloudburstmc.proxypass.network.bedrock.util;
 
-import com.nimbusds.jose.shaded.json.JSONObject;
+import org.cloudburstmc.protocol.bedrock.util.JsonUtils;
 import org.cloudburstmc.proxypass.network.bedrock.session.ProxyPlayerSession;
+import org.jose4j.json.internal.json_simple.JSONObject;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -18,7 +19,7 @@ public class SkinUtils {
     public static final int SKIN_128_128_SIZE = 128 * 128 * PIXEL_SIZE;
 
     public static void saveSkin(ProxyPlayerSession session, JSONObject skinData) {
-        byte[] skin = Base64.getDecoder().decode(skinData.getAsString("SkinData"));
+        byte[] skin = Base64.getDecoder().decode(JsonUtils.childAsType(skinData, "SkinData", String.class));
         int width, height;
         if (skin.length == SINGLE_SKIN_SIZE) {
             width = 64;
@@ -37,10 +38,10 @@ public class SkinUtils {
         }
         saveImage(session, width, height, skin, "skin");
 
-        byte[] cape = Base64.getDecoder().decode(skinData.getAsString("CapeData"));
+        byte[] cape = Base64.getDecoder().decode(JsonUtils.childAsType(skinData, "CapeData", String.class));
         saveImage(session, 64, 32, cape, "cape");
 
-        byte[] geometry = Base64.getDecoder().decode(skinData.getAsString("SkinGeometry"));
+        byte[] geometry = Base64.getDecoder().decode(JsonUtils.childAsType(skinData, "SkinGeometry", String.class));
         session.getLogger().saveJson("geometry", geometry);
     }
 


### PR DESCRIPTION
This has been tested with a vanilla client and BDS, and appears to function without issues.

I have never worked with nimbus or jose4j before, so all feedback is welcome. Additionally, I'm sure there are more ways to better utilise the new IdentityClaims classes introduced, but this was just a quick fix to get it working. Maintainer edits are enabled so feel free.