### PR TITLE
Dump item components

### DIFF
--- a/src/main/java/org/cloudburstmc/proxypass/ProxyPass.java
+++ b/src/main/java/org/cloudburstmc/proxypass/ProxyPass.java
@@ -226,6 +226,16 @@ public class ProxyPass {
             }
         }
     }
+    
+    public void saveCompressedNBT(String dataName, Object dataTag) {
+        Path path = dataDir.resolve(dataName + ".nbt");
+        try (OutputStream outputStream = Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+             NBTOutputStream nbtOutputStream = NbtUtils.createGZIPWriter(outputStream)) {
+            nbtOutputStream.writeTag(dataTag);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     public void saveNBT(String dataName, Object dataTag) {
         Path path = dataDir.resolve(dataName + ".dat");

--- a/src/main/java/org/cloudburstmc/proxypass/network/bedrock/session/DownstreamPacketHandler.java
+++ b/src/main/java/org/cloudburstmc/proxypass/network/bedrock/session/DownstreamPacketHandler.java
@@ -7,6 +7,7 @@ import lombok.Value;
 import lombok.extern.log4j.Log4j2;
 import org.cloudburstmc.nbt.NBTOutputStream;
 import org.cloudburstmc.nbt.NbtMap;
+import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.cloudburstmc.nbt.util.stream.LittleEndianDataOutputStream;
 import org.cloudburstmc.protocol.bedrock.BedrockSession;
 import org.cloudburstmc.protocol.bedrock.data.definitions.BlockDefinition;
@@ -104,6 +105,16 @@ public class DownstreamPacketHandler implements BedrockPacketHandler {
         proxy.saveJson("legacy_item_ids.json", sortMap(legacyItems));
         proxy.saveJson("runtime_item_states.json", itemData);
 
+        return PacketSignal.UNHANDLED;
+    }
+
+    @Override
+    public PacketSignal handle(ItemComponentPacket packet) {
+        NbtMapBuilder root = NbtMap.builder();
+        for (var item : packet.getItems()) {
+            root.putCompound(item.getName(), item.getData().getCompound("components"));
+        }
+        proxy.saveCompressedNBT("item_components", root.build());
         return PacketSignal.UNHANDLED;
     }
 


### PR DESCRIPTION
Writing to GZIP means that NBT browsing with the Minecraft dev plugin for IntelliJ works with the file.