### PR TITLE
Disconnect from server when client disconnects

### DIFF
--- a/src/main/java/org/cloudburstmc/proxypass/network/bedrock/session/UpstreamPacketHandler.java
+++ b/src/main/java/org/cloudburstmc/proxypass/network/bedrock/session/UpstreamPacketHandler.java
@@ -151,4 +151,11 @@ public class UpstreamPacketHandler implements BedrockPacketHandler {
         });
     }
 
+    @Override
+    public void onDisconnect(String reason) {
+        // Disconnect from the bedrock server when the client disconnects
+        if (this.session.getSendSession().isConnected()) {
+            this.session.getSendSession().disconnect(reason);
+        }
+    }
 }


### PR DESCRIPTION
This fixes an annoying issue that means ProxyPass keeps you connected to the backend bedrock server when the client is no longer connected to it.