### PR TITLE
Re-enable AvailableCommandsPacket

### DIFF
--- a/src/main/java/org/cloudburstmc/proxypass/ProxyPass.java
+++ b/src/main/java/org/cloudburstmc/proxypass/ProxyPass.java
@@ -65,10 +65,7 @@ public class ProxyPass {
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     public static final String MINECRAFT_VERSION;
 
-    public static final BedrockCodec CODEC = Bedrock_v800.CODEC
-            .toBuilder()
-            .deregisterPacket(AvailableCommandsPacket.class)
-            .build();
+    public static final BedrockCodec CODEC = Bedrock_v800.CODEC;
 
     public static final int PROTOCOL_VERSION = CODEC.getProtocolVersion();
     private static final BedrockPong ADVERTISEMENT = new BedrockPong()


### PR DESCRIPTION
I assume this was disabled due to parsing issues, but with vanilla BDS 1.21.80 with OP and cheats enabled I'm not having any decoding issues when this is enabled.